### PR TITLE
Patient 경로, 모델, 뷰, urls, 템플릿 추가

### DIFF
--- a/mini/mini/urls.py
+++ b/mini/mini/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('login.urls')),
     path('hospital/', include('hospital.urls')),
+    path('patient/', include('patient.urls')),
 ]

--- a/mini/patient/models.py
+++ b/mini/patient/models.py
@@ -1,3 +1,13 @@
 from django.db import models
+from django.contrib.auth.models import User
 
 # Create your models here.
+
+class Info(models.Model):
+    name = models.CharField('NAME', max_length=50)
+    pid = models.IntegerField('Patient ID', unique=True, blank=True, null=True)
+    description = models.CharField('DESCRIPTION', max_length=100, blank=True, null=True)
+    content = models.TextField('CONTENT')
+    createDate = models.DateTimeField('Create Date', auto_now_add=True)
+    modifyDate = models.DateTimeField('Modify Date', auto_now=True)
+    owner = models.ForeignKey(User, null=True, on_delete=models.CASCADE, related_name='%(class)s_patient_models')

--- a/mini/patient/models.py
+++ b/mini/patient/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 
 class Info(models.Model):
     name = models.CharField('NAME', max_length=50)
-    pid = models.IntegerField('Patient ID', unique=True, blank=True, null=True)
+    pid = models.IntegerField('Patient ID', blank=True, null=True)
     description = models.CharField('DESCRIPTION', max_length=100, blank=True, null=True)
     content = models.TextField('CONTENT')
     createDate = models.DateTimeField('Create Date', auto_now_add=True)

--- a/mini/patient/templates/patient/base.html
+++ b/mini/patient/templates/patient/base.html
@@ -1,0 +1,17 @@
+{% load i18n static %}
+<!DOCTYPE html> {% get_current_language as LANGUAGE_CODE %}
+<html>
+ <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <link rel="stylesheet" href="{% static 'patient/css/bootstrap.min.css' %}"> {% block extra_css %}{% endblock %}
+    <title>{% block title %}My Files{% endblock %}</title>
+</head>
+ <body>
+    <div class="container">
+        {% block content %} {{ content }} {% endblock %}
+    </div>
+    <script src="{% static 'cms/js/jquery-3.3.1.js' %}"></script>
+    <script src="{% static 'cms/js/bootstrap.bundle.min.js' %}"></script> {% block extra_js%}{% endblock %}
+</body>
+ </html

--- a/mini/patient/templates/patient/file_download.html
+++ b/mini/patient/templates/patient/file_download.html
@@ -1,0 +1,8 @@
+<html>
+    <head>
+
+    </head>
+    <body>
+        <div>"hi"</div>
+    </body>
+</html> 

--- a/mini/patient/templates/patient/file_list.html
+++ b/mini/patient/templates/patient/file_list.html
@@ -1,0 +1,25 @@
+{% extends "patient/base.html" %} {% block title %}파일 목록{% endblock %} {% block content %}
+<h4 class="mt-4 border-bottom"> 파일 목록</h4>
+<table class="table table-striped table-bordered">
+    <thead>
+        <tr>
+            <th scope="col">ID</th>
+            <th scope="col">파일명</th>
+            <th scope="col">파일</th>
+            <th scope="col"></th>
+        </tr>
+    </thead>
+<tbody>
+    {% for file in files %}
+    <tr>
+        <th scope="row">{{ file.pid }}</th>
+            <td>{{ file.name }}</td>
+            <td>{{ file.description }}</td>
+            <td>
+                <a href="{% url 'patient:file_download' file_id=file.pid %}" class="btn btn-outline-primary btn-sm">다운로드</a>
+            </td>
+        </tr>
+    {% endfor %}
+</tbody>
+</table>
+{% endblock %} 

--- a/mini/patient/templates/patient/file_list.html
+++ b/mini/patient/templates/patient/file_list.html
@@ -4,6 +4,7 @@
     <thead>
         <tr>
             <th scope="col">ID</th>
+            <th scope="col">PID</th>
             <th scope="col">파일명</th>
             <th scope="col">파일</th>
             <th scope="col"></th>
@@ -12,11 +13,12 @@
 <tbody>
     {% for file in files %}
     <tr>
-        <th scope="row">{{ file.pid }}</th>
+        <th scope="row">{{ file.id }}</th>
+            <td>{{ file.pid }}</td>
             <td>{{ file.name }}</td>
             <td>{{ file.description }}</td>
             <td>
-                <a href="{% url 'patient:file_download' file_id=file.pid %}" class="btn btn-outline-primary btn-sm">다운로드</a>
+                <a href="{% url 'patient:file_download' %}" class="btn btn-outline-primary btn-sm">다운로드</a>
             </td>
         </tr>
     {% endfor %}

--- a/mini/patient/urls.py
+++ b/mini/patient/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import views
+app_name='patient'
+urlpatterns = [
+    path('<int:patient_id>/file/', views.file_list, name='file_list'),
+    path('<int:patient_id>/file/download/', views.file_download, name='file_download'),
+]

--- a/mini/patient/urls.py
+++ b/mini/patient/urls.py
@@ -2,6 +2,9 @@ from django.urls import path
 from . import views
 app_name='patient'
 urlpatterns = [
-    path('<int:patient_id>/file/', views.file_list, name='file_list'),
-    path('<int:patient_id>/file/download/', views.file_download, name='file_download'),
+    path('', views.file_list_all, name='file_list_all'),
+    path('file/', views.file_list_all, name='file_list'),
+    path('file/download/', views.file_download, name='file_download'),
+    path('<int:patient_pid>/file/', views.file_list, name='file_list'),
+    path('<int:patient_pid>/file/download/', views.file_download, name='file_download'),
 ]

--- a/mini/patient/views.py
+++ b/mini/patient/views.py
@@ -1,3 +1,19 @@
-from django.shortcuts import render
+from django.shortcuts import render,get_object_or_404
+from django.http import HttpResponse
+from .models import Info
+# Create your views here.	# Create your views here.
+def file_list(request,patient_id):
+    files=Info.objects.get(pk=patient_id).order_by('id')
+    context={}
+    context['files']=files
 
-# Create your views here.
+    return render(request,'patient/file_list.html',context)
+
+def file_download(request, patient_id):
+    context={}
+    if patient_id:
+        files = get_object_or_404(Info,pk=patient_id)
+        context['files']=files
+    else:
+        return render(request, 'patient/file_list.html',context)
+    return HttpResponse('파일 다운로드')

--- a/mini/patient/views.py
+++ b/mini/patient/views.py
@@ -1,19 +1,25 @@
-from django.shortcuts import render,get_object_or_404
+from django.shortcuts import render,get_object_or_404,get_list_or_404
 from django.http import HttpResponse
-from .models import Info
+from patient.models import Info
+
 # Create your views here.	# Create your views here.
-def file_list(request,patient_id):
-    files=Info.objects.get(pk=patient_id).order_by('id')
+def file_list_all(request):
+    files=Info.objects.order_by('pid')
     context={}
     context['files']=files
 
     return render(request,'patient/file_list.html',context)
 
-def file_download(request, patient_id):
-    context={}
-    if patient_id:
-        files = get_object_or_404(Info,pk=patient_id)
-        context['files']=files
-    else:
-        return render(request, 'patient/file_list.html',context)
+def file_download(request):
     return HttpResponse('파일 다운로드')
+    
+def file_list(request,patient_pid):
+    # files=get_object_or_404(Info)
+    # files=Info.objects.get(pk=patient_pid)
+    # files=Info.objects.order_by('id')
+    # files=Info.objects.all()
+    files=get_list_or_404(Info,pid=patient_pid)
+    context={}
+    context['files']=files
+
+    return render(request,'patient/file_list.html',context)


### PR DESCRIPTION
1. mini 앱의 urls.py에 patient 앱 경로 추가
2. patient 앱의 models.py 추가
3. patient 앱의 views.py 추가
4. patient 앱의 urls.py 추가
5. patient 앱의 templates 폴더와 html 파일 추가
6. patient 앱의 models에서 pid 항목 unique=true 삭제
7. patient 앱의 urls에 파라미터를 환자 pid로 수정
8. patient 앱의 views에서 환자별 목록 리스트 볼 수 있도록 코드 수정
9. patient 앱의 templates의 file_list에 오류발생하던 file_id 제거 -> file.id로 사용하면 되지 않을까 추측